### PR TITLE
Add configuration parameter REST API

### DIFF
--- a/src/main/java/com/example/siscat/controller/ConfigParameterController.java
+++ b/src/main/java/com/example/siscat/controller/ConfigParameterController.java
@@ -1,0 +1,61 @@
+package com.example.siscat.controller;
+
+import com.example.siscat.dto.ConfigParameterDto;
+import com.example.siscat.service.ConfigParameterService;
+import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+@RestController
+@RequestMapping("/config")
+public class ConfigParameterController {
+
+    private final ConfigParameterService service;
+
+    public ConfigParameterController(ConfigParameterService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<ConfigParameterDto> all() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{key}")
+    public ConfigParameterDto get(@PathVariable String key) {
+        return service.findByKey(key);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    public ConfigParameterDto create(@Valid @RequestBody ConfigParameterDto dto) {
+        return service.save(dto);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{key}")
+    public void delete(@PathVariable String key) {
+        service.delete(key);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/logo")
+    public ConfigParameterDto uploadLogo(@RequestParam("file") MultipartFile file) throws IOException {
+        Path uploadDir = Paths.get("uploads");
+        Files.createDirectories(uploadDir);
+        Path target = uploadDir.resolve(file.getOriginalFilename());
+        file.transferTo(target);
+
+        ConfigParameterDto dto = new ConfigParameterDto();
+        dto.setKey("logo.path");
+        dto.setValue(target.toString());
+        return service.save(dto);
+    }
+}

--- a/src/main/java/com/example/siscat/dto/ConfigParameterDto.java
+++ b/src/main/java/com/example/siscat/dto/ConfigParameterDto.java
@@ -1,0 +1,21 @@
+package com.example.siscat.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class ConfigParameterDto {
+    private Long id;
+
+    @NotBlank
+    private String key;
+
+    private String value;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getKey() { return key; }
+    public void setKey(String key) { this.key = key; }
+
+    public String getValue() { return value; }
+    public void setValue(String value) { this.value = value; }
+}

--- a/src/main/java/com/example/siscat/model/ConfigParameter.java
+++ b/src/main/java/com/example/siscat/model/ConfigParameter.java
@@ -1,0 +1,26 @@
+package com.example.siscat.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "config_parameters")
+public class ConfigParameter {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String key;
+
+    @Column(columnDefinition = "text")
+    private String value;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getKey() { return key; }
+    public void setKey(String key) { this.key = key; }
+
+    public String getValue() { return value; }
+    public void setValue(String value) { this.value = value; }
+}

--- a/src/main/java/com/example/siscat/repository/ConfigParameterRepository.java
+++ b/src/main/java/com/example/siscat/repository/ConfigParameterRepository.java
@@ -1,0 +1,10 @@
+package com.example.siscat.repository;
+
+import com.example.siscat.model.ConfigParameter;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ConfigParameterRepository extends JpaRepository<ConfigParameter, Long> {
+    Optional<ConfigParameter> findByKey(String key);
+}

--- a/src/main/java/com/example/siscat/service/ConfigParameterService.java
+++ b/src/main/java/com/example/siscat/service/ConfigParameterService.java
@@ -1,0 +1,51 @@
+package com.example.siscat.service;
+
+import com.example.siscat.dto.ConfigParameterDto;
+import com.example.siscat.exception.ResourceNotFoundException;
+import com.example.siscat.model.ConfigParameter;
+import com.example.siscat.repository.ConfigParameterRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ConfigParameterService {
+
+    private final ConfigParameterRepository repository;
+
+    public ConfigParameterService(ConfigParameterRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<ConfigParameterDto> findAll() {
+        return repository.findAll().stream().map(this::toDto).collect(Collectors.toList());
+    }
+
+    public ConfigParameterDto findByKey(String key) {
+        ConfigParameter param = repository.findByKey(key)
+                .orElseThrow(() -> new ResourceNotFoundException("Config not found"));
+        return toDto(param);
+    }
+
+    public ConfigParameterDto save(ConfigParameterDto dto) {
+        ConfigParameter param = repository.findByKey(dto.getKey()).orElse(new ConfigParameter());
+        param.setKey(dto.getKey());
+        param.setValue(dto.getValue());
+        return toDto(repository.save(param));
+    }
+
+    public void delete(String key) {
+        ConfigParameter param = repository.findByKey(key)
+                .orElseThrow(() -> new ResourceNotFoundException("Config not found"));
+        repository.delete(param);
+    }
+
+    private ConfigParameterDto toDto(ConfigParameter param) {
+        ConfigParameterDto dto = new ConfigParameterDto();
+        dto.setId(param.getId());
+        dto.setKey(param.getKey());
+        dto.setValue(param.getValue());
+        return dto;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,7 @@ jwt.expiration=3600000
 #spring.datasource.username=postgres
 #spring.datasource.password=postgres
 #spring.datasource.driver-class-name=org.postgresql.Driver
+
+# Directory for file uploads
+upload.dir=uploads
+


### PR DESCRIPTION
## Summary
- handle configuration key/value pairs
- expose REST endpoints for config parameters
- store uploaded logo files under `uploads`

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864067c3c7483268862e505205bf25f