### PR TITLE
Implement user session filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ Este proyecto es un ejemplo sencillo de backend usando Spring Boot con autentica
 - `DELETE /persons/{id}` – Eliminar persona (requiere rol `ADMIN`).
 
 La documentación OpenAPI/Swagger se genera en `/swagger-ui.html` cuando la aplicación está en ejecución.
+
+## Sesión de usuario
+
+Cada petición autenticada inicializa un bean `UserSession` con la información del
+usuario logeado, sus roles y los parámetros de configuración relevantes. Este
+bean tiene alcance de petición y puede inyectarse en cualquier controlador o
+servicio.

--- a/src/main/java/com/example/siscat/config/SecurityConfig.java
+++ b/src/main/java/com/example/siscat/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.siscat.config;
 
 import com.example.siscat.repository.UserRepository;
+import com.example.siscat.config.UserSessionFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -21,10 +22,14 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtFilter;
     private final UserRepository userRepository;
+    private final UserSessionFilter userSessionFilter;
 
-    public SecurityConfig(JwtAuthenticationFilter jwtFilter, UserRepository userRepository) {
+    public SecurityConfig(JwtAuthenticationFilter jwtFilter,
+                          UserRepository userRepository,
+                          UserSessionFilter userSessionFilter) {
         this.jwtFilter = jwtFilter;
         this.userRepository = userRepository;
+        this.userSessionFilter = userSessionFilter;
     }
 
     @Bean
@@ -53,7 +58,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/auth/login", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                     .anyRequest().authenticated())
-            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+            .addFilterAfter(userSessionFilter, JwtAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/com/example/siscat/config/UserSessionFilter.java
+++ b/src/main/java/com/example/siscat/config/UserSessionFilter.java
@@ -1,0 +1,68 @@
+package com.example.siscat.config;
+
+import com.example.siscat.dto.ConfigParameterDto;
+import com.example.siscat.model.Role;
+import com.example.siscat.model.User;
+import com.example.siscat.repository.UserRepository;
+import com.example.siscat.service.ConfigParameterService;
+import com.example.siscat.session.UserSession;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Initializes {@link UserSession} for each request after authentication.
+ */
+@Component
+public class UserSessionFilter extends OncePerRequestFilter {
+
+    private final UserRepository userRepository;
+    private final ConfigParameterService configService;
+    private final UserSession userSession;
+
+    public UserSessionFilter(UserRepository userRepository,
+                             ConfigParameterService configService,
+                             UserSession userSession) {
+        this.userRepository = userRepository;
+        this.configService = configService;
+        this.userSession = userSession;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.isAuthenticated() && auth.getPrincipal() instanceof UserDetails principal) {
+            String username = principal.getUsername();
+            User user = userRepository.findByUsername(username).orElse(null);
+            userSession.setUser(user);
+            if (user != null) {
+                List<String> roles = user.getRoles().stream()
+                        .map(Role::getName)
+                        .collect(Collectors.toList());
+                userSession.setRoles(roles);
+            }
+            Map<String, String> config = configService.findAll().stream()
+                    .collect(Collectors.toMap(ConfigParameterDto::getKey, ConfigParameterDto::getValue));
+            userSession.setConfig(config);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return path.startsWith("/auth/login");
+    }
+}

--- a/src/main/java/com/example/siscat/session/UserSession.java
+++ b/src/main/java/com/example/siscat/session/UserSession.java
@@ -1,0 +1,44 @@
+package com.example.siscat.session;
+
+import com.example.siscat.model.User;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+import org.springframework.context.annotation.ScopedProxyMode;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Holds session data for the current authenticated user.
+ */
+@Component
+@RequestScope(proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class UserSession {
+    private User user;
+    private List<String> roles;
+    private Map<String, String> config;
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, String> config) {
+        this.config = config;
+    }
+}


### PR DESCRIPTION
## Summary
- create request-scoped `UserSession` bean to store authenticated user data
- add `UserSessionFilter` that populates the bean on each request
- register the filter in `SecurityConfig`
- document session availability in README

## Testing
- `mvn -q -DskipTests=true package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686409b0a6c483268b5018be6072ac87